### PR TITLE
Update CORS headers to be more strict

### DIFF
--- a/template/Caddyfile
+++ b/template/Caddyfile
@@ -24,8 +24,14 @@ FRONTEND_HOSTNAME {
 }
 
 BACKEND_HOSTNAME {
-	reverse_proxy varnish:80
+	reverse_proxy varnish:80 {
+		# remove `*` from the `Access-Control-Allow-Origin` header
+    header_down -Access-Control-Allow-Origin
+  }
 	header {
+		# enable CORS for the frontend hostname
+		Access-Control-Allow-Origin https://FRONTEND_HOSTNAME
+
 		# disable FLoC tracking
 		Permissions-Policy interest-cohort=()
 
@@ -48,7 +54,8 @@ PROXY_HOSTNAME {
 	}
 
 	header {
-		Access-Control-Allow-Origin *
+		# enable CORS for the frontend hostname
+		Access-Control-Allow-Origin https://FRONTEND_HOSTNAME
 		Access-Control-Allow-Headers *
 
 		# disable FLoC tracking

--- a/template/pipedapi.conf
+++ b/template/pipedapi.conf
@@ -6,5 +6,7 @@ server {
         proxy_pass http://varnish:80;
         proxy_http_version 1.1;
         proxy_set_header Connection "keep-alive";
+        proxy_set_header Access-Control-Allow-Origin FRONTEND_HOSTNAME;
+        proxy_set_header Access-Control-Allow-Headers *;
     }
 }

--- a/template/ytproxy.conf
+++ b/template/ytproxy.conf
@@ -1,4 +1,4 @@
-add_header Access-Control-Allow-Origin *;
+add_header Access-Control-Allow-Origin FRONTEND_HOSTNAME;
 add_header Access-Control-Allow-Headers *;
 if ($request_method = OPTIONS ) {
     return 200;


### PR DESCRIPTION
When running the frontend CORS was set to `*` on the proxy and unset on the API.
Updated to use the `FRONTEND_HOSTNAME` instead.

I ran into this issue trying to get Piped running on my existing caddy setup. This is all I needed to change for it to work
