### PR TITLE
Fix the "Error 503 Backend fetch failed"

### DIFF
--- a/template/docker-compose.caddy.yml
+++ b/template/docker-compose.caddy.yml
@@ -33,7 +33,6 @@ services:
             interval: 10s
             timeout: 10s
             retries: 1
-        
     caddy:
         image: caddy:2-alpine
         restart: unless-stopped

--- a/template/docker-compose.caddy.yml
+++ b/template/docker-compose.caddy.yml
@@ -28,6 +28,12 @@ services:
         container_name: varnish
         depends_on:
             - piped
+        healthcheck:
+            test: ash -c "wget --no-verbose --tries=1 --spider 127.0.0.1:80/trending?region=US || (varnishreload && exit 1)"
+            interval: 10s
+            timeout: 10s
+            retries: 1
+        
     caddy:
         image: caddy:2-alpine
         restart: unless-stopped

--- a/template/docker-compose.nginx.yml
+++ b/template/docker-compose.nginx.yml
@@ -28,6 +28,11 @@ services:
         container_name: varnish
         depends_on:
             - piped
+        healthcheck:
+            test: ash -c "wget --no-verbose --tries=1 --spider 127.0.0.1:80/trending?region=US || (varnishreload && exit 1)"
+            interval: 10s
+            timeout: 10s
+            retries: 1
     nginx:
         image: nginx:mainline-alpine
         restart: unless-stopped


### PR DESCRIPTION
This error was due to the container recreation of the backend (during watchtower updates), varnish didn't know the new local ip of the backend causing the backend to be unreachable