### PR TITLE
support full urls

### DIFF
--- a/configure-instance.sh
+++ b/configure-instance.sh
@@ -1,24 +1,6 @@
-# Check if Docker-Compose is not installed
-if [ -z "$(which docker-compose)" ]; then
-    echo "Docker-Compose is not installed. Please install it first from https://docs.docker.com/compose/install/#install-compose."
-    exit 1
-fi
-
-# Docker-Compose version check, to prevent "Unsupported configuration option"
-COMPOSE_VERSION=$(docker-compose version --short 2>/dev/null || docker compose version --short 2>/dev/null)
-REQUIRED_COMPOSE_VERSION="1.28.0"
-if [[ $(printf '%s\n' "$REQUIRED_COMPOSE_VERSION" "$COMPOSE_VERSION" | sort -V | head -n1) != $REQUIRED_COMPOSE_VERSION ]]; then
-    echo "Your docker-compose version of $COMPOSE_VERSION is too old. Please upgrade to $REQUIRED_COMPOSE_VERSION or higher."
-    echo "See https://docs.docker.com/compose/install/#install-compose for installation instructions."
-    exit 1
-fi
-
-echo "Enter an url for the Frontend (eg: https://piped.kavin.rocks):" && read -r frontend_url
-
-echo "Enter an url for the Backend (eg: https://pipedapi.kavin.rocks):" && read -r backend_url
-
-echo "Enter an hostname for the Proxy (eg: https://pipedproxy.kavin.rocks):" && read -r proxy_url
-
+echo "Enter an url for the Frontend (eg: https://piped.kavin.rocks):" && read -r frontend
+echo "Enter an url for the Backend (eg: https://pipedapi.kavin.rocks):" && read -r backend
+echo "Enter an hostname for the Proxy (eg: https://pipedproxy.kavin.rocks):" && read -r proxy
 echo "Enter the reverse proxy you would like to use (either caddy or nginx):" && read -r reverseproxy
 
 rm -rf config/
@@ -26,9 +8,17 @@ rm -f docker-compose.yml
 
 cp -r template/ config/
 
+frontend_schema=$(echo "$frontend_url"| awk -F[/:] '{print $1}')
+backend_schema=$(echo "$backend_url"| awk -F[/:] '{print $1}')
+proxy_schema=$(echo "$proxy_url"| awk -F[/:] '{print $1}')
+
 frontend_hostname=$(echo "$frontend_url"| awk -F[/:] '{print $4}')
 backend_hostname=$(echo "$backend_url"| awk -F[/:] '{print $4}')
 proxy_hostname=$(echo "$proxy_url"| awk -F[/:] '{print $4}')
+
+frontend_port=$(echo "$frontend_url"| awk -F[/:] '{print $5}'| { read -d '' port; [ -z "$port" ] && { [ "$frontend_schema" = "https" ] && echo "443" || echo "80"; } || echo "$port"; })
+backend_port=$(echo "$backend_url"| awk -F[/:] '{print $5}'| { read -d '' port; [ -z "$port" ] && { [ "$backend_schema" = "https" ] && echo "443" || echo "80"; } || echo "$port"; })
+proxy_port=$(echo "$proxy_url"| awk -F[/:] '{print $5}'| { read -d '' port; [ -z "$port" ] && { [ "$proxy_schema" = "https" ] && echo "443" || echo "80"; } || echo "$port"; })
 
 sed -i "s@FRONT_URL@$frontend_url@g" config/*
 sed -i "s@BACKEND_URL@$backend_url@g" config/*
@@ -37,6 +27,10 @@ sed -i "s@PROXY_URL@$proxy_url@g" config/*
 sed -i "s@FRONTEND_HOSTNAME@$frontend_hostname@g" config/*
 sed -i "s@BACKEND_HOSTNAME@$backend_hostname@g" config/*
 sed -i "s@PROXY_HOSTNAME@$proxy_hostname@g" config/*
+
+sed -i "s@FRONTEND_PORT@$frontend_port@g" config/*
+sed -i "s@BACKEND_PORT@$backend_port@g" config/*
+sed -i "s@PROXY_PORT@$proxy_port@g" config/*
 
 # The openj9 image does not support aarch64
 if [[ "$(uname -m)" == "aarch64" ]]; then

--- a/configure-instance.sh
+++ b/configure-instance.sh
@@ -1,6 +1,6 @@
-echo "Enter an url for the Frontend (eg: https://piped.kavin.rocks):" && read -r frontend
-echo "Enter an url for the Backend (eg: https://pipedapi.kavin.rocks):" && read -r backend
-echo "Enter an hostname for the Proxy (eg: https://pipedproxy.kavin.rocks):" && read -r proxy
+echo "Enter an url for the Frontend (eg: https://piped.kavin.rocks):" && read -r frontend_url
+echo "Enter an url for the Backend (eg: https://pipedapi.kavin.rocks):" && read -r backend_url
+echo "Enter an hostname for the Proxy (eg: https://pipedproxy.kavin.rocks):" && read -r proxy_url
 echo "Enter the reverse proxy you would like to use (either caddy or nginx):" && read -r reverseproxy
 
 rm -rf config/
@@ -20,21 +20,21 @@ frontend_port=$(echo "$frontend_url"| awk -F[/:] '{print $5}'| { read -d '' port
 backend_port=$(echo "$backend_url"| awk -F[/:] '{print $5}'| { read -d '' port; [ -z "$port" ] && { [ "$backend_schema" = "https" ] && echo "443" || echo "80"; } || echo "$port"; })
 proxy_port=$(echo "$proxy_url"| awk -F[/:] '{print $5}'| { read -d '' port; [ -z "$port" ] && { [ "$proxy_schema" = "https" ] && echo "443" || echo "80"; } || echo "$port"; })
 
-sed -i "s@FRONT_URL@$frontend_url@g" config/*
-sed -i "s@BACKEND_URL@$backend_url@g" config/*
-sed -i "s@PROXY_URL@$proxy_url@g" config/*
+sed -i '' "s@FRONT_URL@$frontend_url@g" config/*
+sed -i '' "s@BACKEND_URL@$backend_url@g" config/*
+sed -i '' "s@PROXY_URL@$proxy_url@g" config/*
 
-sed -i "s@FRONTEND_HOSTNAME@$frontend_hostname@g" config/*
-sed -i "s@BACKEND_HOSTNAME@$backend_hostname@g" config/*
-sed -i "s@PROXY_HOSTNAME@$proxy_hostname@g" config/*
+sed -i '' "s@FRONTEND_HOSTNAME@$frontend_hostname@g" config/*
+sed -i '' "s@BACKEND_HOSTNAME@$backend_hostname@g" config/*
+sed -i '' "s@PROXY_HOSTNAME@$proxy_hostname@g" config/*
 
-sed -i "s@FRONTEND_PORT@$frontend_port@g" config/*
-sed -i "s@BACKEND_PORT@$backend_port@g" config/*
-sed -i "s@PROXY_PORT@$proxy_port@g" config/*
+sed -i '' "s@FRONTEND_PORT@$frontend_port@g" config/*
+sed -i '' "s@BACKEND_PORT@$backend_port@g" config/*
+sed -i '' "s@PROXY_PORT@$proxy_port@g" config/*
 
 # The openj9 image does not support aarch64
 if [[ "$(uname -m)" == "aarch64" ]]; then
-    sed -i "s/piped:latest/piped:hotspot/g" config/*
+    sed -i '' "s/piped:latest/piped:hotspot/g" config/*
 fi
 
 mv config/docker-compose.$reverseproxy.yml docker-compose.yml

--- a/configure-instance.sh
+++ b/configure-instance.sh
@@ -1,11 +1,11 @@
-echo "Enter a hostname for the Frontend (eg: piped.kavin.rocks):"
-read frontend
+echo "Enter an url for the Frontend (eg: https://piped.kavin.rocks):"
+read frontend_url
 
-echo "Enter a hostname for the Backend (eg: pipedapi.kavin.rocks):"
-read backend
+echo "Enter an url for the Backend (eg: https://pipedapi.kavin.rocks):"
+read backend_url
 
-echo "Enter a hostname for the Proxy (eg: pipedproxy.kavin.rocks):"
-read proxy
+echo "Enter an hostname for the Proxy (eg: https://pipedproxy.kavin.rocks):"
+read proxy_url
 
 echo "Enter the reverse proxy you would like to use (either caddy or nginx):"
 read reverseproxy
@@ -15,8 +15,16 @@ rm -f docker-compose.yml
 
 cp -r template/ config/
 
-sed -i "s/FRONTEND_HOSTNAME/$frontend/g" config/*
-sed -i "s/BACKEND_HOSTNAME/$backend/g" config/*
-sed -i "s/PROXY_HOSTNAME/$proxy/g" config/*
+frontend_hostname=$(echo "$frontend_url"| awk -F[/:] '{print $4}')
+backend_hostname=$(echo "$backend_url"| awk -F[/:] '{print $4}')
+proxy_hostname=$(echo "$proxy_url"| awk -F[/:] '{print $4}')
+
+sed -i "s@FRONT_URL@$frontend_url@g" config/*
+sed -i "s@BACKEND_URL@$backend_url@g" config/*
+sed -i "s@PROXY_URL@$proxy_url@g" config/*
+
+sed -i "s@FRONTEND_HOSTNAME@$frontend_hostname@g" config/*
+sed -i "s@BACKEND_HOSTNAME@$backend_hostname@g" config/*
+sed -i "s@PROXY_HOSTNAME@$proxy_hostname@g" config/*
 
 mv config/docker-compose.$reverseproxy.yml docker-compose.yml

--- a/configure-instance.sh
+++ b/configure-instance.sh
@@ -15,11 +15,11 @@ fi
 
 echo "Enter an url for the Frontend (eg: https://piped.kavin.rocks):" && read -r frontend_url
 
-echo "Enter an url for the Backend (eg: https://pipedapi.kavin.rocks):"" && read -r backend_url
+echo "Enter an url for the Backend (eg: https://pipedapi.kavin.rocks):" && read -r backend_url
 
 echo "Enter an hostname for the Proxy (eg: https://pipedproxy.kavin.rocks):" && read -r proxy_url
 
-echo "Enter the reverse proxy you would like to use (either caddy or nginx):"" && read -r reverseproxy
+echo "Enter the reverse proxy you would like to use (either caddy or nginx):" && read -r reverseproxy
 
 rm -rf config/
 rm -f docker-compose.yml

--- a/configure-instance.sh
+++ b/configure-instance.sh
@@ -17,7 +17,7 @@ echo "Enter an url for the Frontend (eg: https://piped.kavin.rocks):" && read -r
 
 echo "Enter an url for the Backend (eg: https://pipedapi.kavin.rocks):"" && read -r backend_url
 
-echo "Enter an hostname for the Proxy (eg: https://pipedproxy.kavin.rocks):"" && read -r proxy_url
+echo "Enter an hostname for the Proxy (eg: https://pipedproxy.kavin.rocks):" && read -r proxy_url
 
 echo "Enter the reverse proxy you would like to use (either caddy or nginx):"" && read -r reverseproxy
 

--- a/configure-instance.sh
+++ b/configure-instance.sh
@@ -20,6 +20,8 @@ frontend_port=$(echo "$frontend_url"| awk -F[/:] '{print $5}'| { read -d '' port
 backend_port=$(echo "$backend_url"| awk -F[/:] '{print $5}'| { read -d '' port; [ -z "$port" ] && { [ "$backend_schema" = "https" ] && echo "443" || echo "80"; } || echo "$port"; })
 proxy_port=$(echo "$proxy_url"| awk -F[/:] '{print $5}'| { read -d '' port; [ -z "$port" ] && { [ "$proxy_schema" = "https" ] && echo "443" || echo "80"; } || echo "$port"; })
 
+nginx_ports=$(printf "$frontend_port\n$backend_port\n$proxy_port\n"|uniq|while read -r port; do printf "            - \"$port:$port\"\\\n"; done)
+
 sed -i '' "s@FRONT_URL@$frontend_url@g" config/*
 sed -i '' "s@BACKEND_URL@$backend_url@g" config/*
 sed -i '' "s@PROXY_URL@$proxy_url@g" config/*
@@ -31,6 +33,8 @@ sed -i '' "s@PROXY_HOSTNAME@$proxy_hostname@g" config/*
 sed -i '' "s@FRONTEND_PORT@$frontend_port@g" config/*
 sed -i '' "s@BACKEND_PORT@$backend_port@g" config/*
 sed -i '' "s@PROXY_PORT@$proxy_port@g" config/*
+
+sed -i '' "s@NGINX_PORTS@$nginx_ports@g" config/*
 
 # The openj9 image does not support aarch64
 if [[ "$(uname -m)" == "aarch64" ]]; then

--- a/configure-instance.sh
+++ b/configure-instance.sh
@@ -5,7 +5,7 @@ if [ -z "$(which docker-compose)" ]; then
 fi
 
 # Docker-Compose version check, to prevent "Unsupported configuration option"
-COMPOSE_VERSION=$(docker-compose version --short)
+COMPOSE_VERSION=$(docker-compose version --short 2>/dev/null || docker compose version --short 2>/dev/null)
 REQUIRED_COMPOSE_VERSION="1.28.0"
 if [[ $(printf '%s\n' "$REQUIRED_COMPOSE_VERSION" "$COMPOSE_VERSION" | sort -V | head -n1) != $REQUIRED_COMPOSE_VERSION ]]; then
     echo "Your docker-compose version of $COMPOSE_VERSION is too old. Please upgrade to $REQUIRED_COMPOSE_VERSION or higher."

--- a/configure-instance.sh
+++ b/configure-instance.sh
@@ -22,23 +22,41 @@ proxy_port=$(echo "$proxy_url"| awk -F[/:] '{print $5}'| { read -d '' port; [ -z
 
 nginx_ports=$(printf "$frontend_port\n$backend_port\n$proxy_port\n"|uniq|while read -r port; do printf "            - \"$port:$port\"\\\n"; done)
 
-sed -i '' "s@FRONT_URL@$frontend_url@g" config/*
-sed -i '' "s@BACKEND_URL@$backend_url@g" config/*
-sed -i '' "s@PROXY_URL@$proxy_url@g" config/*
+case $OSTYPE in
+    darwin*)
+      function ased(){
+        sed -i '' "$@"
+      }
+      ;;
+    freebsd*)
+      function ased(){
+        sed -i '' "$@"
+      }
+      ;;
+    linux*)
+      function ased(){
+        sed -i "$@"
+      }
+      ;;
+esac
 
-sed -i '' "s@FRONTEND_HOSTNAME@$frontend_hostname@g" config/*
-sed -i '' "s@BACKEND_HOSTNAME@$backend_hostname@g" config/*
-sed -i '' "s@PROXY_HOSTNAME@$proxy_hostname@g" config/*
+ased "s@FRONT_URL@$frontend_url@g" config/*
+ased "s@BACKEND_URL@$backend_url@g" config/*
+ased "s@PROXY_URL@$proxy_url@g" config/*
 
-sed -i '' "s@FRONTEND_PORT@$frontend_port@g" config/*
-sed -i '' "s@BACKEND_PORT@$backend_port@g" config/*
-sed -i '' "s@PROXY_PORT@$proxy_port@g" config/*
+ased "s@FRONTEND_HOSTNAME@$frontend_hostname@g" config/*
+ased "s@BACKEND_HOSTNAME@$backend_hostname@g" config/*
+ased "s@PROXY_HOSTNAME@$proxy_hostname@g" config/*
 
-sed -i '' "s@NGINX_PORTS@$nginx_ports@g" config/*
+ased "s@FRONTEND_PORT@$frontend_port@g" config/*
+ased "s@BACKEND_PORT@$backend_port@g" config/*
+ased "s@PROXY_PORT@$proxy_port@g" config/*
+
+ased "s@NGINX_PORTS@$nginx_ports@g" config/*
 
 # The openj9 image does not support aarch64
 if [[ "$(uname -m)" == "aarch64" ]]; then
-    sed -i '' "s/piped:latest/piped:hotspot/g" config/*
+    ased "s/piped:latest/piped:hotspot/g" config/*
 fi
 
 mv config/docker-compose.$reverseproxy.yml docker-compose.yml

--- a/template/config.properties
+++ b/template/config.properties
@@ -20,6 +20,15 @@ API_URL: BACKEND_URL
 # Public Frontend URL
 FRONTEND_URL: FRONT_URL
 
+# Enable haveibeenpwned compromised password API
+COMPROMISED_PASSWORD_CHECK: true
+
+# Disable Registration
+DISABLE_REGISTRATION: false
+
+# Feed Retention Time in Days
+FEED_RETENTION: 30
+
 # Hibernate properties
 hibernate.connection.url: jdbc:postgresql://postgres:5432/piped
 hibernate.connection.driver_class: org.postgresql.Driver

--- a/template/config.properties
+++ b/template/config.properties
@@ -32,6 +32,6 @@ FEED_RETENTION: 30
 # Hibernate properties
 hibernate.connection.url: jdbc:postgresql://postgres:5432/piped
 hibernate.connection.driver_class: org.postgresql.Driver
-hibernate.dialect: org.hibernate.dialect.PostgreSQL10Dialect
+hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
 hibernate.connection.username: piped
 hibernate.connection.password: changeme

--- a/template/config.properties
+++ b/template/config.properties
@@ -5,7 +5,7 @@ PORT: 8080
 HTTP_WORKERS: 2
 
 # Proxy
-PROXY_PART: https://PROXY_HOSTNAME
+PROXY_PART: PROXY_URL
 
 # Outgoing HTTP Proxy - eg: 127.0.0.1:8118
 #HTTP_PROXY: 127.0.0.1:8118
@@ -15,10 +15,10 @@ CAPTCHA_BASE_URL: https://api.capmonster.cloud/
 CAPTCHA_API_KEY: INSERT_HERE
 
 # Public API URL
-API_URL: https://BACKEND_HOSTNAME
+API_URL: BACKEND_URL
 
 # Public Frontend URL
-FRONTEND_URL: https://FRONTEND_HOSTNAME
+FRONTEND_URL: FRONT_URL
 
 # Hibernate properties
 hibernate.connection.url: jdbc:postgresql://postgres:5432/piped

--- a/template/docker-compose.caddy.yml
+++ b/template/docker-compose.caddy.yml
@@ -5,7 +5,7 @@ services:
         depends_on:
             - piped
         container_name: piped-frontend
-        entrypoint: ash -c 'sed -i s/pipedapi.kavin.rocks/BACKEND_HOSTNAME/g /usr/share/nginx/html/js/* && /docker-entrypoint.sh && nginx -g "daemon off;"'
+        entrypoint: ash -c 'sed -i s@https://pipedapi.kavin.rocks@BACKEND_URL@g /usr/share/nginx/html/js/* && /docker-entrypoint.sh && nginx -g "daemon off;"'
     ytproxy:
         image: 1337kavin/ytproxy:latest
         restart: unless-stopped

--- a/template/docker-compose.caddy.yml
+++ b/template/docker-compose.caddy.yml
@@ -1,3 +1,5 @@
+version: "3"
+
 services:
     pipedfrontend:
         image: 1337kavin/piped-frontend:latest
@@ -5,9 +7,7 @@ services:
         depends_on:
             - piped
         container_name: piped-frontend
-        entrypoint: ash -c 'sed -i s@https://pipedapi.kavin.rocks@BACKEND_URL@g
-            /usr/share/nginx/html/assets/* && /docker-entrypoint.sh && nginx -g
-            "daemon off;"'
+        entrypoint: ash -c 'sed -i s@https://pipedapi.kavin.rocks@BACKEND_URL@g /usr/share/nginx/html/assets/* && /docker-entrypoint.sh && nginx -g "daemon off;"'
     ytproxy:
         image: 1337kavin/ytproxy:latest
         restart: unless-stopped
@@ -31,8 +31,7 @@ services:
         depends_on:
             - piped
         healthcheck:
-            test: ash -c "wget --no-verbose --tries=1 --spider 127.0.0.1:80/feed ||
-                (varnishreload && exit 1)"
+            test: ash -c "wget --no-verbose --tries=1 --spider 127.0.0.1:80/feed || (varnishreload && exit 1)"
             interval: 10s
             timeout: 10s
             retries: 1

--- a/template/docker-compose.nginx.yml
+++ b/template/docker-compose.nginx.yml
@@ -5,7 +5,7 @@ services:
         depends_on:
             - piped
         container_name: piped-frontend
-        entrypoint: ash -c 'sed -i s/pipedapi.kavin.rocks/BACKEND_HOSTNAME/g /usr/share/nginx/html/js/* && /docker-entrypoint.sh && nginx -g "daemon off;"'
+        entrypoint: ash -c 'sed -i s@https://pipedapi.kavin.rocks@BACKEND_URL@g /usr/share/nginx/html/js/* && /docker-entrypoint.sh && nginx -g "daemon off;"'
     ytproxy:
         image: 1337kavin/ytproxy:latest
         restart: unless-stopped

--- a/template/docker-compose.nginx.yml
+++ b/template/docker-compose.nginx.yml
@@ -39,9 +39,7 @@ services:
         image: nginx:mainline-alpine
         restart: unless-stopped
         ports:
-            - "FRONTEND_PORT:FRONTEND_PORT"
-            - "BACKEND_PORT:BACKEND_PORT"
-            - "PROXY_PORT:PROXY_PORT"
+NGINX_PORTS
         volumes:
             - ./config/nginx.conf:/etc/nginx/nginx.conf:ro
             - ./config/pipedapi.conf:/etc/nginx/conf.d/pipedapi.conf:ro

--- a/template/docker-compose.nginx.yml
+++ b/template/docker-compose.nginx.yml
@@ -39,7 +39,9 @@ services:
         image: nginx:mainline-alpine
         restart: unless-stopped
         ports:
-            - "8080:80"
+            - "FRONTEND_PORT:FRONTEND_PORT"
+            - "BACKEND_PORT:BACKEND_PORT"
+            - "PROXY_PORT:PROXY_PORT"
         volumes:
             - ./config/nginx.conf:/etc/nginx/nginx.conf:ro
             - ./config/pipedapi.conf:/etc/nginx/conf.d/pipedapi.conf:ro

--- a/template/docker-compose.nginx.yml
+++ b/template/docker-compose.nginx.yml
@@ -1,3 +1,5 @@
+version: "3"
+
 services:
     pipedfrontend:
         image: 1337kavin/piped-frontend:latest
@@ -5,9 +7,7 @@ services:
         depends_on:
             - piped
         container_name: piped-frontend
-        entrypoint: ash -c 'sed -i s@https://pipedapi.kavin.rocks@BACKEND_URL@g
-            /usr/share/nginx/html/assets/* && /docker-entrypoint.sh && nginx -g
-            "daemon off;"'
+        entrypoint: ash -c 'sed -i s@https://pipedapi.kavin.rocks@BACKEND_URL@g /usr/share/nginx/html/assets/* && /docker-entrypoint.sh && nginx -g "daemon off;"'
     ytproxy:
         image: 1337kavin/ytproxy:latest
         restart: unless-stopped
@@ -31,8 +31,7 @@ services:
         depends_on:
             - piped
         healthcheck:
-            test: ash -c "wget --no-verbose --tries=1 --spider 127.0.0.1:80/feed ||
-                (varnishreload && exit 1)"
+            test: ash -c "wget --no-verbose --tries=1 --spider 127.0.0.1:80/feed || (varnishreload && exit 1)"
             interval: 10s
             timeout: 10s
             retries: 1

--- a/template/nginx.conf
+++ b/template/nginx.conf
@@ -27,5 +27,7 @@ http {
 
     gzip on;
 
+    resolver 127.0.0.11 ipv6=off valid=10s;
+
     include /etc/nginx/conf.d/*.conf;
 }

--- a/template/pipedapi.conf
+++ b/template/pipedapi.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen BACKEND_PORT;
     server_name BACKEND_HOSTNAME;
 
     set $backend "http://varnish:80";

--- a/template/pipedapi.conf
+++ b/template/pipedapi.conf
@@ -2,8 +2,10 @@ server {
     listen 80;
     server_name BACKEND_HOSTNAME;
 
+    set $backend "http://varnish:80";
+
     location / {
-        proxy_pass http://varnish:80;
+        proxy_pass $backend;
         proxy_http_version 1.1;
         proxy_set_header Connection "keep-alive";
     }

--- a/template/pipedfrontend.conf
+++ b/template/pipedfrontend.conf
@@ -2,8 +2,10 @@ server {
     listen 80;
     server_name FRONTEND_HOSTNAME;
 
+    set $backend "http://pipedfrontend:80";
+
     location / {
-        proxy_pass http://pipedfrontend:80;
+        proxy_pass $backend;
         proxy_http_version 1.1;
         proxy_set_header Connection "keep-alive";
     }

--- a/template/pipedfrontend.conf
+++ b/template/pipedfrontend.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen FRONTEND_PORT;
     server_name FRONTEND_HOSTNAME;
 
     set $backend "http://pipedfrontend:80";

--- a/template/pipedproxy.conf
+++ b/template/pipedproxy.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen PROXY_PORT;
     server_name PROXY_HOSTNAME;
 
     location ~ (/videoplayback|/api/v4/|/api/manifest/) {


### PR DESCRIPTION
Asking for full urls in `configure-instance.sh` and extracting hosts improve portability of the script
On nginx backend this enable plain http support, while with caddy the requests on http are redirected to https