### PR TITLE
Varnish config: replace hostname piped with hostname piped-backend to…

### DIFF
--- a/template/default.vcl
+++ b/template/default.vcl
@@ -1,5 +1,5 @@
 vcl 4.0;
 
 backend default {
-  .host = "piped:8080";
+  .host = "piped-backend:8080";
 }


### PR DESCRIPTION
… clearly use the appopriate hostname to avoid problems with the docker-magic and prevent confusion after hostname changes.