### PR TITLE
Update Caddyfile

### DIFF
--- a/template/Caddyfile
+++ b/template/Caddyfile
@@ -1,61 +1,32 @@
-{
-	servers :443 {
-		protocol {
-			experimental_http3
-		}
+(global) {
+	header {
+		# disable FLoC tracking
+		Permissions-Policy interest-cohort=()
+
+		# enable HSTS
+		Strict-Transport-Security max-age=31536000;
+
+		# keep referrer data off
+		Referrer-Policy no-referrer
+
+		# prevent for appearing in search engine for private instances (option)
+		#X-Robots-Tag noindex
 	}
 }
 
 FRONTEND_HOSTNAME {
 	reverse_proxy pipedfrontend:80
-	header {
-		# disable FLoC tracking
-		Permissions-Policy interest-cohort=()
-
-		# enable HSTS
-		Strict-Transport-Security max-age=31536000;
-
-		# keep referrer data off
-		Referrer-Policy no-referrer
-
-		# prevent for appearing in search engine for private instances (option)
-		#X-Robots-Tag noindex
-	}
+	import global
 }
 
 BACKEND_HOSTNAME {
 	reverse_proxy varnish:80
-	header {
-		# disable FLoC tracking
-		Permissions-Policy interest-cohort=()
-
-		# enable HSTS
-		Strict-Transport-Security max-age=31536000;
-
-		# keep referrer data off
-		Referrer-Policy no-referrer
-
-		# prevent for appearing in search engine for private instances (option)
-		#X-Robots-Tag noindex
-	}
+	import global
 }
 
 PROXY_HOSTNAME {
 	@ytproxy path /videoplayback* /api/v4/* /api/manifest/*
-
-	header {
-		# disable FLoC tracking
-		Permissions-Policy interest-cohort=()
-
-		# enable HSTS
-		Strict-Transport-Security max-age=31536000;
-
-		# keep referrer data off
-		Referrer-Policy no-referrer
-
-		# prevent for appearing in search engine for private instances (option)
-		#X-Robots-Tag noindex
-	}
+	import global
 
 	route {
 		header @ytproxy {


### PR DESCRIPTION
Caddy 2.6 removes the experimental_http3 option and supports http3 by default. Fixes https://github.com/TeamPiped/Piped/issues/1469 
And merged the duplicate headers into snippets.

