### PR TITLE
Add handling of non-standard ports

### DIFF
--- a/configure-instance.sh
+++ b/configure-instance.sh
@@ -3,7 +3,14 @@ echo "Enter a hostname for the Frontend (eg: piped.kavin.rocks):" && read -r fro
 echo "Enter a hostname for the Backend (eg: pipedapi.kavin.rocks):" && read -r backend
 echo "Enter a hostname for the Proxy (eg: pipedproxy.kavin.rocks):" && read -r proxy
 echo "Enter the reverse proxy you would like to use (either caddy or nginx):" && read -r reverseproxy
-echo "Enter a port to use for the reverse proxy:" && read -r port
+port=8080 # Define default port
+if [[ $reverseproxy = "nginx" ]]; then # if the nginx reverse proxy is used, we want to get a custom port
+    echo "Enter a port to use for the reverse proxy:" && read -r port
+fi
+integerregex='^[0-9]+$'
+if ! [[ $port =~ $integerregex ]] ; then # ensure that the port is an integer. If it is not set it to the default.
+    port=8080
+fi
 
 rm -rf config/
 rm -f docker-compose.yml

--- a/configure-instance.sh
+++ b/configure-instance.sh
@@ -3,6 +3,7 @@ echo "Enter a hostname for the Frontend (eg: piped.kavin.rocks):" && read -r fro
 echo "Enter a hostname for the Backend (eg: pipedapi.kavin.rocks):" && read -r backend
 echo "Enter a hostname for the Proxy (eg: pipedproxy.kavin.rocks):" && read -r proxy
 echo "Enter the reverse proxy you would like to use (either caddy or nginx):" && read -r reverseproxy
+echo "Enter a port to use for the reverse proxy:" && read -r port
 
 rm -rf config/
 rm -f docker-compose.yml
@@ -12,5 +13,6 @@ cp -r template/ config/
 sed -i "s/FRONTEND_HOSTNAME/$frontend/g" config/*
 sed -i "s/BACKEND_HOSTNAME/$backend/g" config/*
 sed -i "s/PROXY_HOSTNAME/$proxy/g" config/*
+sed -i "s/PORT_VALUE/$port/g" config/*
 
 mv config/docker-compose.$reverseproxy.yml docker-compose.yml

--- a/template/config.properties
+++ b/template/config.properties
@@ -1,5 +1,5 @@
 # The port to Listen on.
-PORT: 8080
+PORT: PORT_VALUE
 
 # The number of workers to use for the server
 HTTP_WORKERS: 2

--- a/template/docker-compose.caddy.yml
+++ b/template/docker-compose.caddy.yml
@@ -24,6 +24,8 @@ services:
         depends_on:
             - postgres
         container_name: piped-backend
+        environment:
+          - PORT=PORT_VALUE
     nginx:
         image: nginx:mainline-alpine
         restart: unless-stopped
@@ -31,13 +33,15 @@ services:
             - ./config/nginx.conf:/etc/nginx/nginx.conf:ro
             - ./config/pipedapi.conf:/etc/nginx/conf.d/pipedapi.conf:ro
         container_name: nginx
+        environment:
+          - PORT=PORT_VALUE
         depends_on:
             - piped
     caddy:
         image: caddy:2-alpine
         restart: unless-stopped
         ports:
-            - "80:80"
+            - "PORT_VALUE:80"
             - "443:443"
             - "443:443/udp"
         volumes:

--- a/template/docker-compose.caddy.yml
+++ b/template/docker-compose.caddy.yml
@@ -24,8 +24,6 @@ services:
         depends_on:
             - postgres
         container_name: piped-backend
-        environment:
-          - PORT=PORT_VALUE
     nginx:
         image: nginx:mainline-alpine
         restart: unless-stopped
@@ -33,15 +31,13 @@ services:
             - ./config/nginx.conf:/etc/nginx/nginx.conf:ro
             - ./config/pipedapi.conf:/etc/nginx/conf.d/pipedapi.conf:ro
         container_name: nginx
-        environment:
-          - PORT=PORT_VALUE
         depends_on:
             - piped
     caddy:
         image: caddy:2-alpine
         restart: unless-stopped
         ports:
-            - "PORT_VALUE:80"
+            - "80:80"
             - "443:443"
             - "443:443/udp"
         volumes:

--- a/template/docker-compose.nginx.yml
+++ b/template/docker-compose.nginx.yml
@@ -24,8 +24,6 @@ services:
         depends_on:
             - postgres
         container_name: piped-backend
-        environment:
-          - PORT=PORT_VALUE
     nginx:
         image: nginx:mainline-alpine
         restart: unless-stopped
@@ -48,9 +46,6 @@ services:
             - "traefik.http.routers.piped.rule=Host(`FRONTEND_HOSTNAME`, `BACKEND_HOSTNAME`, `PROXY_HOSTNAME`)"
             - "traefik.http.routers.piped.entrypoints=websecure"
             - "traefik.http.services.piped.loadbalancer.server.port=PORT_VALUE"
-        environment:
-          - PORT=PORT_VALUE
-
     postgres:
         image: postgres:15
         restart: unless-stopped

--- a/template/docker-compose.nginx.yml
+++ b/template/docker-compose.nginx.yml
@@ -45,7 +45,7 @@ services:
             - "traefik.enable=true"
             - "traefik.http.routers.piped.rule=Host(`FRONTEND_HOSTNAME`, `BACKEND_HOSTNAME`, `PROXY_HOSTNAME`)"
             - "traefik.http.routers.piped.entrypoints=websecure"
-            - "traefik.http.services.piped.loadbalancer.server.port=PORT_VALUE"
+            - "traefik.http.services.piped.loadbalancer.server.port=8080"
     postgres:
         image: postgres:15
         restart: unless-stopped

--- a/template/docker-compose.nginx.yml
+++ b/template/docker-compose.nginx.yml
@@ -24,11 +24,13 @@ services:
         depends_on:
             - postgres
         container_name: piped-backend
+        environment:
+          - PORT=PORT_VALUE
     nginx:
         image: nginx:mainline-alpine
         restart: unless-stopped
         ports:
-            - "8080:80"
+            - "PORT_VALUE:80"
         volumes:
             - ./config/nginx.conf:/etc/nginx/nginx.conf:ro
             - ./config/pipedapi.conf:/etc/nginx/conf.d/pipedapi.conf:ro
@@ -45,7 +47,10 @@ services:
             - "traefik.enable=true"
             - "traefik.http.routers.piped.rule=Host(`FRONTEND_HOSTNAME`, `BACKEND_HOSTNAME`, `PROXY_HOSTNAME`)"
             - "traefik.http.routers.piped.entrypoints=websecure"
-            - "traefik.http.services.piped.loadbalancer.server.port=8080"
+            - "traefik.http.services.piped.loadbalancer.server.port=PORT_VALUE"
+        environment:
+          - PORT=PORT_VALUE
+
     postgres:
         image: postgres:15
         restart: unless-stopped

--- a/template/pipedapi.conf
+++ b/template/pipedapi.conf
@@ -4,7 +4,7 @@ server {
     listen 80;
     server_name BACKEND_HOSTNAME;
 
-    set $backend "http://piped:8080";
+    set $backend "http://piped:PORT_VALUE";
 
     location / {
         proxy_cache pipedapi;


### PR DESCRIPTION
The default port instantiated by the self-hosting system sues port 8080. There might be users who already use that port for something else. As such, this should allow for an easy set up for those users who might wish to use a different port. 
Please note that I was unable to test the caddy set up, as such it might not function correctly. However, this appears to work for nginx. 