### PR TITLE
Add flake for NixOS servers support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,7 @@
+{
+  inputs = { nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05"; };
+
+  outputs = { nixpkgs, ... }@inputs: {
+    nixosModules = { default = import ./nix; };
+  };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,1 @@
+{ ... }: { imports = [ ./options.nix ./piped.nix ]; }

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -1,0 +1,48 @@
+{ lib, ... }:
+
+{
+  options = with lib; {
+    piped = {
+        enable = mkOption {
+            description = "Enable the piped service";
+            type = types.bool;
+            default = false;
+        };
+
+        # Config for configure-instance.sh
+        frontend = mkOption {
+            description = "Hostname for the Frontend (eg: piped.kavin.rocks)";
+            type = types.str;
+        };
+        backend = mkOption {
+            description = "Hostname for the Backend (eg: pipedapi.kavin.rocks)";
+            type = types.str;
+        };
+        proxy = mkOption {
+            description = "Hostname for the Proxy (eg: pipedproxy.kavin.rocks)";
+            type = types.str;
+        };
+        reverseproxy = mkOption {
+            description = "Reverse proxy you would like to use (either caddy or nginx)";
+            type = types.str;
+        };
+
+        # Additional Config
+        dataDir = mkOption {
+            description = "The path for data storage";
+            type = types.str;
+            default = "/var/lib/piped";
+        };
+        httpPort = mkOption {
+            description = "The port to listen for HTTP conenctions";
+            type = types.int;
+            default = 80;
+        };
+        httpsPort = mkOption {
+            description = "The port to listen for HTTPS conenctions";
+            type = types.int;
+            default = 443;
+        };
+    };
+  };
+}

--- a/nix/piped-package.nix
+++ b/nix/piped-package.nix
@@ -1,0 +1,27 @@
+{ stdenvNoCC, bash, pipedConfig }:
+
+stdenvNoCC.mkDerivation rec {
+  name = "piped";
+
+  src = ../template;
+  installer = ../configure-instance.sh;
+
+  preferLocalBuild = true;
+
+  installPhase = ''
+    mkdir -p "$out/template"
+    cp -r . "$out/template"
+    cd "$out"
+    ${bash}/bin/bash ${installer} <<<$(
+        echo ${pipedConfig.frontend}
+        echo ${pipedConfig.backend}
+        echo ${pipedConfig.proxy}
+        echo ${pipedConfig.reverseproxy}
+    )
+    rm -rf $out/template
+
+    sed "s|80:|${builtins.toString pipedConfig.httpPort}:|g" -i docker-compose.yml
+    sed "s|443:|${builtins.toString pipedConfig.httpsPort}:|g" -i docker-compose.yml
+    sed "s|\./data|${pipedConfig.dataDir}|g" -i docker-compose.yml
+  '';
+}

--- a/nix/piped.nix
+++ b/nix/piped.nix
@@ -1,0 +1,19 @@
+{ config, lib, pkgs, ... }:
+
+let
+    pipedPackage = pkgs.callPackage ./piped-package.nix { pipedConfig = config.piped; };
+in lib.mkIf config.piped.enable {
+    virtualisation.docker.enable = true;
+    systemd.services.piped = {
+        enable = true;
+        serviceConfig = {
+            WorkingDirectory = pipedPackage;
+            preStart = "${pkgs.docker-compose}/bin/docker-compose pull";
+            ExecStart = "${pkgs.docker-compose}/bin/docker-compose up";
+            ExecStop = "${pkgs.docker-compose}/bin/docker-compose down";
+        };
+        environment.COMPOSE_PROJECT_NAME = "piped-flake";
+        after = [ "docker.service" "docker.socket" ];
+        wantedBy = [ "multi-user.target" ];
+    };
+}


### PR DESCRIPTION
This a NixOS wrapper around the installation script for easier integration on NixOS servers.

It runs Docker Compose as a systemd service and exposes the CLI configuration options as nix options, ex:
```nix
{ ... }: {
	piped = {
		frontend = "piped.kavin.rocks";
		backend = "pipedapi.kavin.rocks";
		proxy = "pipedproxy.kavin.rocks";
		reverseproxy = "caddy";
	};
}
```

It also exposes some additional options:
```nix
{ ... }: {
	piped = {
		httpPort = 80; # Default
		httpsPort = 443; # Default
		dataDir = "/var/lib/piped"; # Default
	};
}
```