### PR TITLE
Update depends_on service name from 'pipedfrontend' to 'piped-frontend' in docker-compose.nginx.yml

### DIFF
--- a/template/docker-compose.nginx.yml
+++ b/template/docker-compose.nginx.yml
@@ -39,7 +39,7 @@ services:
         depends_on:
             - piped
             - piped-proxy
-            - pipedfrontend
+            - piped-frontend
         labels:
             - "traefik.enable=true"
             - "traefik.http.routers.piped.rule=Host(`FRONTEND_HOSTNAME`, `BACKEND_HOSTNAME`, `PROXY_HOSTNAME`)"


### PR DESCRIPTION
```bash
$ docker compose up -d
service "nginx" depends on undefined service "pipedfrontend": invalid compose project
```