### PR TITLE
Fix frontend hostname in Caddyfile

### DIFF
--- a/template/Caddyfile
+++ b/template/Caddyfile
@@ -15,7 +15,7 @@
 }
 
 FRONTEND_HOSTNAME {
-	reverse_proxy pipedfrontend:80
+	reverse_proxy piped-frontend:80
 	import global
 }
 


### PR DESCRIPTION
As can be seen [in the Dockerfile](https://github.com/TeamPiped/Piped-Docker/blob/b6f7da34b6c7e1e6e1694ee450db1b305e0a9b58/template/docker-compose.caddy.yml#L9C25-L9C39), the hostname of the frontend is `piped-frontend`. This PR fixes the Caddyfiles to make the frontend reachable.