### PR TITLE
feat: add stanalone installation process

### DIFF
--- a/configure-instance.sh
+++ b/configure-instance.sh
@@ -2,7 +2,7 @@
 echo "Enter a hostname for the Frontend (eg: piped.kavin.rocks):" && read -r frontend
 echo "Enter a hostname for the Backend (eg: pipedapi.kavin.rocks):" && read -r backend
 echo "Enter a hostname for the Proxy (eg: pipedproxy.kavin.rocks):" && read -r proxy
-echo "Enter the reverse proxy you would like to use (either caddy or nginx):" && read -r reverseproxy
+echo "Enter the reverse proxy you would like to use (caddy, nginx or standalone):" && read -r reverseproxy
 echo "Is your hostname reachable via HTTP or HTTPS? (eg: https)" && read -r http_mode
 
 rm -rf config/

--- a/template/docker-compose.standalone.yml
+++ b/template/docker-compose.standalone.yml
@@ -1,0 +1,41 @@
+services:
+    piped-frontend:
+        image: 1337kavin/piped-frontend:latest
+        restart: unless-stopped
+        depends_on:
+            - piped
+        environment:
+            BACKEND_HOSTNAME: BACKEND_HOSTNAME_PLACEHOLDER
+            HTTP_MODE: HTTP_MODE_PLACEHOLDER
+        ports:
+            - "8080:80"
+        container_name: piped-frontend
+
+    piped-backend:
+        image: 1337kavin/piped:latest
+        restart: unless-stopped
+        volumes:
+            - ./config/config.properties:/app/config.properties:ro
+        depends_on:
+            - postgres
+        ports:
+            - "8081:8080"
+        container_name: piped-backend
+
+    piped-proxy:
+        image: 1337kavin/piped-proxy:latest
+        restart: unless-stopped
+        ports:
+            - "8082:8080"
+        container_name: piped-proxy
+
+    piped-postgres:
+        image: pgautoupgrade/pgautoupgrade:16-alpine
+        restart: unless-stopped
+        volumes:
+            - ./data/db:/var/lib/postgresql/data
+        environment:
+            - POSTGRES_DB=piped
+            - POSTGRES_USER=piped
+            - POSTGRES_PASSWORD=changeme
+        container_name: piped-postgres


### PR DESCRIPTION
This aims to make it easier to install Piped for local development and for advanced users that don't want to host an additional layer of reverse proxies in docker when they already have one setup...