### PR TITLE
Fix docker traefik labels on compose template

### DIFF
--- a/template/docker-compose.nginx.yml
+++ b/template/docker-compose.nginx.yml
@@ -47,7 +47,7 @@ services:
             - piped-frontend
         labels:
             - "traefik.enable=true"
-            - "traefik.http.routers.piped.rule=Host(`FRONTEND_HOSTNAME`, `BACKEND_HOSTNAME`, `PROXY_HOSTNAME`)"
+            - "traefik.http.routers.piped.rule=Host(`FRONTEND_HOSTNAME`) || Host(`BACKEND_HOSTNAME`) || Host(`PROXY_HOSTNAME`)"
             - "traefik.http.routers.piped.entrypoints=websecure"
             - "traefik.http.services.piped.loadbalancer.server.port=8080"
     postgres:


### PR DESCRIPTION
I've updated the compose template so it reflects the traefik configuration docs (docker labels part). Now, traefik requires a different way of [configuring hosts in router rules](https://doc.traefik.io/traefik/routing/routers/#rule).