### PR TITLE
Replace obsolete watchtower image in docker composes

### DIFF
--- a/template/docker-compose.caddy.yml
+++ b/template/docker-compose.caddy.yml
@@ -60,7 +60,7 @@ services:
             - POSTGRES_PASSWORD=changeme
         container_name: postgres
     watchtower:
-        image: beatkind/watchtower
+        image: nickfedor/watchtower
         restart: always
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock

--- a/template/docker-compose.caddy.yml
+++ b/template/docker-compose.caddy.yml
@@ -60,7 +60,7 @@ services:
             - POSTGRES_PASSWORD=changeme
         container_name: postgres
     watchtower:
-        image: containrrr/watchtower
+        image: beatkind/watchtower
         restart: always
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock

--- a/template/docker-compose.nginx.yml
+++ b/template/docker-compose.nginx.yml
@@ -61,7 +61,7 @@ services:
             - POSTGRES_PASSWORD=changeme
         container_name: postgres
     watchtower:
-        image: containrrr/watchtower
+        image: beatkind/watchtower
         restart: always
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock

--- a/template/docker-compose.nginx.yml
+++ b/template/docker-compose.nginx.yml
@@ -61,7 +61,7 @@ services:
             - POSTGRES_PASSWORD=changeme
         container_name: postgres
     watchtower:
-        image: beatkind/watchtower
+        image: nickfedor/watchtower
         restart: always
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Used beatkind/watchtower, it is not official, but it works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automatic container-update service used in our Docker Compose templates for both Caddy and Nginx deployments to a different upstream image to ensure consistent, reliable automated container updates across supported deployment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->